### PR TITLE
Rewrite of caching method: use a background thread instead of  LVN_ODCACHEHINT message

### DIFF
--- a/WinAudio/Globals2.h
+++ b/WinAudio/Globals2.h
@@ -2,7 +2,7 @@
 #define GLOBALS2_H
 
 // Increase at every commit
-#define MW_ID_BUILD_NR					3
+#define MW_ID_BUILD_NR					4
 
 #define MAINWINDOW_WIDTH				640
 #define MAINWINDOW_HEIGHT				480
@@ -97,6 +97,7 @@ struct
 
 
 	HANDLE hCacheAbort;
+	HANDLE hCacheSemaphore;
 	HANDLE hCacheThread;
 	CRITICAL_SECTION CacheThreadSection;
 	bool bCacheThreadFail;

--- a/WinAudio/Globals2.h
+++ b/WinAudio/Globals2.h
@@ -2,7 +2,7 @@
 #define GLOBALS2_H
 
 // Increase at every commit
-#define MW_ID_BUILD_NR					2
+#define MW_ID_BUILD_NR					3
 
 #define MAINWINDOW_WIDTH				640
 #define MAINWINDOW_HEIGHT				480
@@ -94,6 +94,12 @@ struct
 
 	TOOLINFO PositionToolInfo;
 	HWND hPositionTool;
+
+
+	HANDLE hCacheAbort;
+	HANDLE hCacheThread;
+	CRITICAL_SECTION CacheThreadSection;
+	bool bCacheThreadFail;
 } Globals2;
 
 

--- a/WinAudio/WA_GEN_Playlist.h
+++ b/WinAudio/WA_GEN_Playlist.h
@@ -51,4 +51,6 @@ bool WA_Playlist_Get_SelectedIndex(WA_Playlist* This, DWORD *dwIndex);
 bool WA_Playlist_LoadM3U(WA_Playlist* This, const wchar_t* pFilePath);
 bool WA_Playlist_SaveAsM3U(WA_Playlist* This, const wchar_t* pFilePath);
 
+void WA_Playlist_CacheNextItem(WA_Playlist* This);
+
 #endif

--- a/WinAudio/WA_UI_ListView.c
+++ b/WinAudio/WA_UI_ListView.c
@@ -26,6 +26,7 @@ static wchar_t WA_Listview_Column_Path[] = L"File Path\0";
 
 // Process Custom Draw (Recived in a form of WM_NOTIFY)
 LRESULT WA_UI_Listview_CustomDraw(HWND hWnd, LPNMLVCUSTOMDRAW lplvcd);
+DWORD WINAPI WA_ListView_CacheThread(_In_ LPVOID lpParameter);
 
 WA_Listview_Column Columns[WA_LISTVIEW_COLUMNS_COUNT];
 
@@ -358,13 +359,17 @@ static void WA_UI_Listview_DeleteSelected(HWND hListview)
 
     while (nCounter > -1)
     {
+        EnterCriticalSection(&Globals2.CacheThreadSection);
         WA_Playlist_Remove(Globals2.pPlaylist, IntArray[nCounter]);
+        LeaveCriticalSection(&Globals2.CacheThreadSection);
         nCounter--;
     }
 
     free(IntArray);
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
     
 }
 
@@ -422,8 +427,10 @@ static void WA_UI_Listview_ShowItemContextMenu(HWND hListview, int32_t x, int32_
 
         if (Globals2.pPlaylist)
         {
+            EnterCriticalSection(&Globals2.CacheThreadSection);
             WA_Playlist_RemoveAll(Globals2.pPlaylist);
             WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+            LeaveCriticalSection(&Globals2.CacheThreadSection);
         }
     }
 
@@ -522,7 +529,9 @@ static void WA_Listview_GetItem(NMLVDISPINFO* pInfo)
     WA_Playlist_Metadata* pMetadata;
     DWORD dwColumnID;
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     pMetadata = WA_Playlist_Get_Item(Globals2.pPlaylist, pInfo->item.iItem);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     _ASSERT(pMetadata);
 
@@ -536,10 +545,19 @@ static void WA_Listview_GetItem(NMLVDISPINFO* pInfo)
         switch (dwColumnID)
         {
         case WA_LISTVIEW_COLUMN_STATUS:
-            if(pMetadata->bFileSelected)
-                wcscpy_s(pInfo->item.pszText, pInfo->item.cchTextMax, L"->\0");
+            if (pMetadata->bFileReaded)
+            {
+                if (pMetadata->bFileSelected)
+                    wcscpy_s(pInfo->item.pszText, pInfo->item.cchTextMax, L"->\0");
+                else
+                    wcscpy_s(pInfo->item.pszText, pInfo->item.cchTextMax, L"\0");
+                
+            }
             else
-                wcscpy_s(pInfo->item.pszText, pInfo->item.cchTextMax, L"\0");
+            {
+                wcscpy_s(pInfo->item.pszText, pInfo->item.cchTextMax, L"Reading..\0");
+            }
+
             break;
         case WA_LISTVIEW_COLUMN_INDEX:
         {
@@ -621,14 +639,17 @@ static void WA_Listview_GetItem(NMLVDISPINFO* pInfo)
 
 static void WA_Listview_PrepCache(NMLVCACHEHINT *pCache)
 {   
-    WA_Playlist_UpdateCache(Globals2.pPlaylist, (DWORD) pCache->iFrom,(DWORD) pCache->iTo);
+    // Use slow caching if we fail to create caching thread
+    if(Globals2.bCacheThreadFail)
+        WA_Playlist_UpdateCache(Globals2.pPlaylist, (DWORD) pCache->iFrom,(DWORD) pCache->iTo);
 }
 
 static LRESULT WA_Listview_FindItem(LPNMLVFINDITEM pFindItem)
 {
     LVFINDINFOW* pFindInfo = &pFindItem->lvfi;
-    DWORD dwStartIndex = (DWORD)(pFindItem->iStart) % WA_Playlist_Get_Count(Globals2.pPlaylist);
+    DWORD dwStartIndex;
     DWORD dwFoundIndex;
+    bool bResult;
 
     /*
 
@@ -647,11 +668,13 @@ static LRESULT WA_Listview_FindItem(LPNMLVFINDITEM pFindItem)
     if (!Globals2.pPlaylist)
         return -1;
 
-    if(!WA_Playlist_FindByFirstChar(Globals2.pPlaylist, 
-        dwStartIndex, 
-        pFindInfo->psz, 
-        &dwFoundIndex))   
-        return -1;
+    EnterCriticalSection(&Globals2.CacheThreadSection);
+    dwStartIndex = (DWORD)(pFindItem->iStart) % WA_Playlist_Get_Count(Globals2.pPlaylist);
+    bResult = WA_Playlist_FindByFirstChar(Globals2.pPlaylist, dwStartIndex, pFindInfo->psz, &dwFoundIndex);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
+    
+    if (!bResult)    
+        return -1;          
 
     return (LRESULT)dwFoundIndex;
 }
@@ -671,7 +694,9 @@ static void WA_Listview_ReorderSelectedItems(HWND hListview, INT uTargetIndex)
     if (!Globals2.pPlaylist)
         return;
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     dwCount = WA_Playlist_Get_Count(Globals2.pPlaylist);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     if (dwCount < (DWORD)uTargetIndex)
         return;
@@ -702,7 +727,9 @@ static void WA_Listview_ReorderSelectedItems(HWND hListview, INT uTargetIndex)
         
     }
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     WA_Playlist_ReorderIndexes(Globals2.pPlaylist, ItemsArray, uSelectedCount, (DWORD)uTargetIndex);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     free(ItemsArray);
 
@@ -726,8 +753,8 @@ static void WA_Listview_OpenSelectedItem(HWND hListview)
     nIndex = ListView_GetNextItem(hListview, -1, LVNI_SELECTED);
 
     if (nIndex != -1)
-    {
-        MainWindow_Open_Playlist_Index(nIndex);
+    {      
+        MainWindow_Open_Playlist_Index(nIndex);        
     }
 }
 
@@ -870,6 +897,14 @@ LRESULT CALLBACK WA_UI_Listview_Proc(HWND hWnd, UINT uMsg, WPARAM wParam,
         case VK_DELETE:
         case VK_BACK:
             WA_UI_Listview_DeleteSelected(hWnd);
+            return 0;
+        case 0x41: // CTRL + A -> Select All
+            if(GetAsyncKeyState(VK_CONTROL))
+                ListView_SetItemState(hWnd, -1, LVIS_SELECTED, LVIS_SELECTED);
+            return 0;
+        case 0x44:  // CTRL + D -> Deselect All
+            if (GetAsyncKeyState(VK_CONTROL))
+              ListView_SetItemState(hWnd, -1, 0, LVIS_SELECTED);
             return 0;
         }           
 
@@ -1106,13 +1141,46 @@ HWND WA_UI_Listview_Create(HWND hOwner, PRECT pRect)
      
 
     // Create Columns
-    WA_UI_Listview_InitColumns(hListview);
+    WA_UI_Listview_InitColumns(hListview);   
+
+    // Create Caching Thread
+    InitializeCriticalSection(&Globals2.CacheThreadSection);
+
+    Globals2.hCacheAbort = CreateEvent(NULL, FALSE, FALSE, L"CacheAbortEvent");
+    Globals2.hCacheThread = NULL;
+
+    if (Globals2.hCacheAbort)
+        Globals2.hCacheThread = CreateThread(NULL, 0, WA_ListView_CacheThread, Globals2.pPlaylist, 0, NULL);
+       
+    // Use slow caching on fail to create thread
+    if (!Globals2.hCacheThread)
+        Globals2.bCacheThreadFail = true;
+    else
+        Globals2.bCacheThreadFail = false;
 
     return hListview;
 }
 
 VOID WA_UI_Listview_Destroy(HWND hListview)
-{
+{  
+
+   
+    if (Globals2.hCacheAbort)
+    {
+        // Close Caching Thread
+        if (Globals2.hCacheThread)
+        {
+            SetEvent(Globals2.hCacheAbort);
+            WaitForSingleObject(Globals2.hCacheThread, INFINITE);
+            CloseHandle(Globals2.hCacheThread);
+        }
+
+        CloseHandle(Globals2.hCacheAbort);
+    }         
+
+    DeleteCriticalSection(&Globals2.CacheThreadSection);
+  
+
     if (Globals2.pPlaylist)
         WA_Playlist_Delete(Globals2.pPlaylist);
 }
@@ -1211,4 +1279,30 @@ VOID WA_UI_Listview_LoadSettings(HWND hListview)
 
 
     WA_Ini_Delete(pIni);
+}
+
+
+DWORD WINAPI WA_ListView_CacheThread(_In_ LPVOID lpParameter)
+{    
+    bool bAbort = false;
+
+    while (!bAbort)
+    {
+        DWORD dwResult;
+
+        dwResult = WaitForSingleObject(Globals2.hCacheAbort, WA_LISTVIEW_CACHING_TIMEOUT);
+
+        if (dwResult == WAIT_OBJECT_0)
+            bAbort = true;        
+
+
+        if (Globals2.pPlaylist)
+        {
+            EnterCriticalSection(&Globals2.CacheThreadSection);
+            WA_Playlist_CacheNextItem(Globals2.pPlaylist);
+            LeaveCriticalSection(&Globals2.CacheThreadSection);
+        }         
+    }
+
+    return EXIT_SUCCESS;
 }

--- a/WinAudio/WA_UI_ListView.h
+++ b/WinAudio/WA_UI_ListView.h
@@ -46,5 +46,8 @@ VOID WA_UI_Listview_Destroy(HWND hListview);
 VOID WA_UI_Listview_SaveSettings(HWND hListview);
 VOID WA_UI_Listview_LoadSettings(HWND hListview);
 
+// Signal to Cache Thread that main window is ready
+VOID WA_ListView_RunCacheThread();
+
 
 #endif

--- a/WinAudio/WA_UI_ListView.h
+++ b/WinAudio/WA_UI_ListView.h
@@ -11,8 +11,10 @@
 #define WA_LISTVIEW_COLUMN_SIZE             0x0040
 #define WA_LISTVIEW_COLUMN_PATH             0x0080
 
-#define WA_LISTVIEW_COLUMNS_COUNT   8
-#define WA_LISTVIEW_PRINTF_MAX      100
+#define WA_LISTVIEW_COLUMNS_COUNT           8
+#define WA_LISTVIEW_PRINTF_MAX              100
+
+#define WA_LISTVIEW_CACHING_TIMEOUT         50 // In Ms
 
 
 // Store Columns Order and Visibility

--- a/WinAudio/main.c
+++ b/WinAudio/main.c
@@ -243,6 +243,9 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     ShowWindow(Globals2.hMainWindow, nShowCmd);
     UpdateWindow(Globals2.hMainWindow);
 
+    // Run Playlist Caching Thread
+    WA_ListView_RunCacheThread();
+
     _RPTW1(_CRT_WARN, L"DPI: %u\n", GetDpiForWindow(Globals2.hMainWindow));
 
     // Run the message loop.

--- a/WinAudio/main.c
+++ b/WinAudio/main.c
@@ -288,18 +288,25 @@ void MainWindow_ProcessStartupFiles(int32_t nParams, wchar_t** pArgs)
     for (i = 1; i < nParams; i++)
     {
         // Check if file exist
-        if (PathFileExists(pArgs[i]))        
-            WA_Playlist_Add(Globals2.pPlaylist, pArgs[i]);         
+        if (PathFileExists(pArgs[i]))
+        {
+            EnterCriticalSection(&Globals2.CacheThreadSection);
+            WA_Playlist_Add(Globals2.pPlaylist, pArgs[i]);
+            LeaveCriticalSection(&Globals2.CacheThreadSection);
+        }
+                   
                
     }
 
     // Update Listview Count
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     // Open and Play file at Index [0]
     if (MainWindow_Open_Playlist_Index(0)) 
         MainWindow_Play();
-  
+    
   
         
 
@@ -669,8 +676,10 @@ void MainWindow_HandleCommand(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case ID_PLAYLIST_DELETEALL:
         if (Globals2.pPlaylist)
         {
+            EnterCriticalSection(&Globals2.CacheThreadSection);
             WA_Playlist_RemoveAll(Globals2.pPlaylist);
             WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+            LeaveCriticalSection(&Globals2.CacheThreadSection);
         }
 
         break;
@@ -920,7 +929,10 @@ HWND MainWindow_CreateListView(HWND hOwnerHandle)
     ListRect.right = WindowRect.right;
     ListRect.bottom = WindowRect.bottom - RebarRect.bottom - StatusRect.bottom;
 
-
+    /*
+    In this function we load Listview settings, and create Playlist object
+    used in main.c. We create also Caching thread and
+    */
     hListview = WA_UI_Listview_Create(hOwnerHandle, &ListRect);
 
     SetWindowSubclass(hListview, WA_UI_Listview_Proc, MW_ID_LISTVIEW, 0);
@@ -944,8 +956,8 @@ HWND MainWindow_CreateListView(HWND hOwnerHandle)
 void MainWindow_DestroyListView()
 {
     WA_UI_Listview_SaveSettings(Globals2.hListView);
-    WA_UI_Listview_Destroy(Globals2.hListView);
     RemoveWindowSubclass(Globals2.hListView, WA_UI_Listview_Proc, MW_ID_LISTVIEW);
+    WA_UI_Listview_Destroy(Globals2.hListView);    
 }
 
 /// <summary>
@@ -995,8 +1007,10 @@ void MainWindow_CreateUI(HWND hMainWindow)
 
             if (MainWindow_GetPlaylistSaveFolder(PlaylistPath))
             {
+                EnterCriticalSection(&Globals2.CacheThreadSection);
                 WA_Playlist_LoadM3U(Globals2.pPlaylist, PlaylistPath);
                 WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+                LeaveCriticalSection(&Globals2.CacheThreadSection);
             }           
 
 
@@ -1037,7 +1051,12 @@ void MainWindow_DestroyUI()
         wchar_t PlaylistPath[MAX_PATH];
 
         if (MainWindow_GetPlaylistSaveFolder(PlaylistPath))
+        {
+            EnterCriticalSection(&Globals2.CacheThreadSection);
             WA_Playlist_SaveAsM3U(Globals2.pPlaylist, PlaylistPath);
+            LeaveCriticalSection(&Globals2.CacheThreadSection);
+        }
+            
         
     }
 
@@ -1435,7 +1454,9 @@ bool MainWindow_OpenFileDialog(HWND hOwnerHandle)
                     IShellItem* pItem;
 
                     // Clear Playlist
+                    EnterCriticalSection(&Globals2.CacheThreadSection);
                     WA_Playlist_RemoveAll(Globals2.pPlaylist);
+                    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
                     // Get The Path of Each Selected File
                     for (DWORD i = 0U; i < dwFilesCount; i++)
@@ -1453,7 +1474,12 @@ bool MainWindow_OpenFileDialog(HWND hOwnerHandle)
 
                                 // Add item to Playlist
                                 if (WA_Playback_Engine_IsFileSupported(pszFilePath))
+                                {
+                                    EnterCriticalSection(&Globals2.CacheThreadSection);
                                     WA_Playlist_Add(Globals2.pPlaylist, pszFilePath);
+                                    LeaveCriticalSection(&Globals2.CacheThreadSection);
+                                }
+                                    
 
                                 CoTaskMemFree(pszFilePath);
                             }
@@ -1465,7 +1491,9 @@ bool MainWindow_OpenFileDialog(HWND hOwnerHandle)
                     }
 
                     // Update Listview Count
+                    EnterCriticalSection(&Globals2.CacheThreadSection);
                     WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+                    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
                     // Open First Index in the playlist
                     MainWindow_Open_Playlist_Index(0);
@@ -1562,8 +1590,13 @@ bool MainWindow_AddFilesDialog(HWND hOwnerHandle)
                             if SUCCEEDED(hr)
                             {
                                 
-                                if(WA_Playback_Engine_IsFileSupported(pszFilePath))                          
+                                if (WA_Playback_Engine_IsFileSupported(pszFilePath))
+                                {
+                                    EnterCriticalSection(&Globals2.CacheThreadSection);
                                     WA_Playlist_Add(Globals2.pPlaylist, pszFilePath);
+                                    LeaveCriticalSection(&Globals2.CacheThreadSection);
+                                }
+                                   
 
                                 CoTaskMemFree(pszFilePath);
                             }
@@ -1575,7 +1608,9 @@ bool MainWindow_AddFilesDialog(HWND hOwnerHandle)
                     }
 
                     // Update Listview Count
+                    EnterCriticalSection(&Globals2.CacheThreadSection);
                     WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+                    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
                 }
 
@@ -1624,7 +1659,12 @@ static void MainWindow_Folder2Playlist(const LPWSTR pszFilePath)
         wcscat_s(lpwFilePath, MAX_PATH, data.cFileName);
 
         if (WA_Playback_Engine_IsFileSupported(lpwFilePath))
+        {
+            EnterCriticalSection(&Globals2.CacheThreadSection);
             WA_Playlist_Add(Globals2.pPlaylist, lpwFilePath);
+            LeaveCriticalSection(&Globals2.CacheThreadSection);
+        }
+           
 
     } while (FindNextFile(hFind, &data) != 0);
 
@@ -1632,7 +1672,10 @@ static void MainWindow_Folder2Playlist(const LPWSTR pszFilePath)
     FindClose(hFind);
 
     // Update Listview Count
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
+   
 
 }
 
@@ -1754,8 +1797,10 @@ bool MainWindow_OpenPlaylistDialog(HWND hOwnerHandle)
                     if SUCCEEDED(hr)
                     {
                         // Clear Playlist and load new one
+                        EnterCriticalSection(&Globals2.CacheThreadSection);
                         WA_Playlist_RemoveAll(Globals2.pPlaylist);                
                         WA_Playlist_LoadM3U(Globals2.pPlaylist, pszFilePath);
+                        LeaveCriticalSection(&Globals2.CacheThreadSection);
 
                         CoTaskMemFree(pszFilePath);
                     }
@@ -1764,7 +1809,9 @@ bool MainWindow_OpenPlaylistDialog(HWND hOwnerHandle)
                 }              
 
                 // Update Listview Count
+                EnterCriticalSection(&Globals2.CacheThreadSection);
                 WA_Playlist_UpdateView(Globals2.pPlaylist, false);         
+                LeaveCriticalSection(&Globals2.CacheThreadSection);
 
                 IShellItemArray_Release(pItemsArray);
             }
@@ -1823,7 +1870,9 @@ bool MainWindow_SaveAsPlaylistDialog(HWND hOwnerHandle)
                 if SUCCEEDED(hr)
                 {
                    
+                    EnterCriticalSection(&Globals2.CacheThreadSection);
                     WA_Playlist_SaveAsM3U(Globals2.pPlaylist, pszFilePath);
+                    LeaveCriticalSection(&Globals2.CacheThreadSection);
                     CoTaskMemFree(pszFilePath);
                 }
 
@@ -1982,7 +2031,9 @@ bool MainWindow_NextItem()
     if (!Globals2.pPlaylist)
         return false;
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     dwCount = WA_Playlist_Get_Count(Globals2.pPlaylist);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     if (dwCount < 1)
         return false;
@@ -2010,7 +2061,9 @@ bool MainWindow_PreviousItem()
     if (!Globals2.pPlaylist)
         return false;
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     dwCount = WA_Playlist_Get_Count(Globals2.pPlaylist);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     if (dwCount < 1)
         return false;
@@ -2041,7 +2094,9 @@ bool MainWindow_Open_Playlist_Index(DWORD dwIndex)
     if (!Globals2.pPlaylist)
         return false;
 
+    EnterCriticalSection(&Globals2.CacheThreadSection);
     pMetadata = WA_Playlist_Get_Item(Globals2.pPlaylist, dwIndex);
+    LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     if (!pMetadata)
         return false;
@@ -2053,8 +2108,10 @@ bool MainWindow_Open_Playlist_Index(DWORD dwIndex)
     // Update Listview
     if (Globals2.pPlaylist)
     {
+        EnterCriticalSection(&Globals2.CacheThreadSection);
         WA_Playlist_SelectIndex(Globals2.pPlaylist, dwIndex);
         WA_Playlist_UpdateView(Globals2.pPlaylist, true);
+        LeaveCriticalSection(&Globals2.CacheThreadSection);
     }
 
     MainWindow_Play();
@@ -2120,12 +2177,13 @@ bool MainWindow_Close()
     {
         DWORD dwIndex = 0;
 
+        EnterCriticalSection(&Globals2.CacheThreadSection);
         if (WA_Playlist_Get_SelectedIndex(Globals2.pPlaylist, &dwIndex))
         {
             WA_Playlist_DeselectIndex(Globals2.pPlaylist, dwIndex);
             WA_Playlist_UpdateView(Globals2.pPlaylist, true);
         }
-
+        LeaveCriticalSection(&Globals2.CacheThreadSection);
 
     }
 
@@ -2644,12 +2702,13 @@ LRESULT MainWindow_HandleCopyData(HWND hWnd, WPARAM wParam, LPARAM lParam)
         if (!WA_Playback_Engine_IsFileSupported((wchar_t*)lpCopy->lpData))
             return FALSE;
 
+        EnterCriticalSection(&Globals2.CacheThreadSection);
         WA_Playlist_RemoveAll(Globals2.pPlaylist);
-
         WA_Playlist_Add(Globals2.pPlaylist, (wchar_t*) lpCopy->lpData);
 
         // Update Listview Count
         WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+        LeaveCriticalSection(&Globals2.CacheThreadSection);
 
         // Open and Play file at Index [0]
         if (MainWindow_Open_Playlist_Index(0)) 
@@ -2667,10 +2726,12 @@ LRESULT MainWindow_HandleCopyData(HWND hWnd, WPARAM wParam, LPARAM lParam)
         if (!WA_Playback_Engine_IsFileSupported((wchar_t*)lpCopy->lpData))
             return FALSE;
        
+        EnterCriticalSection(&Globals2.CacheThreadSection);
         WA_Playlist_Add(Globals2.pPlaylist, (wchar_t*)lpCopy->lpData);
 
         // Update Listview Count
         WA_Playlist_UpdateView(Globals2.pPlaylist, false);
+        LeaveCriticalSection(&Globals2.CacheThreadSection);
 
         break;
     }
@@ -2891,7 +2952,9 @@ HRESULT STDMETHODCALLTYPE Drop(IDropTarget* This, IDataObject* pDataObj, DWORD g
             {         
                 if (WA_Playback_Engine_IsFileSupported(FilePath))
                 {
+                    EnterCriticalSection(&Globals2.CacheThreadSection);
                     WA_Playlist_Add(Globals2.pPlaylist, FilePath);
+                    LeaveCriticalSection(&Globals2.CacheThreadSection);
                     dwAddedFiles++;
                 }                      
             }
@@ -2901,8 +2964,10 @@ HRESULT STDMETHODCALLTYPE Drop(IDropTarget* This, IDataObject* pDataObj, DWORD g
 
     if (dwAddedFiles > 0)
     {
+        EnterCriticalSection(&Globals2.CacheThreadSection);
         WA_Playlist_UpdateView(Globals2.pPlaylist, false);
         dwLastIndex = WA_Playlist_Get_Count(Globals2.pPlaylist) - 1U;
+        LeaveCriticalSection(&Globals2.CacheThreadSection);
 
         ListView_EnsureVisible(Globals2.hListView, dwLastIndex, FALSE);
     }


### PR DESCRIPTION
Improve UI performance using a background thread to cache playlist items instead of [LVN_ODCACHEHINT](https://learn.microsoft.com/en-us/windows/win32/controls/lvn-odcachehint)

The Listview use LVN_ODCACHEHINT if Background thread or sync events cannot be created.