### PR TITLE
Implemented sorting in playlist and LoadM3U Bugfix

### DIFF
--- a/WinAudio/Globals2.h
+++ b/WinAudio/Globals2.h
@@ -2,7 +2,7 @@
 #define GLOBALS2_H
 
 // Increase at every commit
-#define MW_ID_BUILD_NR					4
+#define MW_ID_BUILD_NR					5
 
 #define MAINWINDOW_WIDTH				640
 #define MAINWINDOW_HEIGHT				480

--- a/WinAudio/WA_GEN_Playlist.h
+++ b/WinAudio/WA_GEN_Playlist.h
@@ -5,6 +5,23 @@
 #define WA_PLAYLIST_INITIAL_MAX_SIZE 50
 #define WA_PLAYLIST_REALLOC_BLOCK 100
 
+// Sort By
+enum WA_PLAYLIST_SORT_BY
+{
+	WA_PLAYLIST_SORT_BY_ARTIST_TITLE,
+	WA_PLAYLIST_SORT_BY_ALBUM,
+	WA_PLAYLIST_SORT_BY_GENRE,
+	WA_PLAYLIST_SORT_BY_DURATION,
+	WA_PLAYLIST_SORT_BY_SIZE,
+	WA_PLAYLIST_SORT_BY_PATH
+};
+
+enum WA_PLAYLIST_SORT_ORDER
+{
+	WA_PLAYLIST_SORT_UP,
+	WA_PLAYLIST_SORT_DOWN
+};
+
 // Opaque Type
 struct TagWA_Playlist;
 typedef struct TagWA_Playlist WA_Playlist;
@@ -52,5 +69,23 @@ bool WA_Playlist_LoadM3U(WA_Playlist* This, const wchar_t* pFilePath);
 bool WA_Playlist_SaveAsM3U(WA_Playlist* This, const wchar_t* pFilePath);
 
 void WA_Playlist_CacheNextItem(WA_Playlist* This);
+
+void WA_Playlist_Sort(WA_Playlist* This, DWORD dwSortBy, int32_t nSortOrder);
+
+
+inline void WA_Playlist_Merge_Artist_Title(wchar_t* pBuffer, DWORD dwBufferSize, const wchar_t* pArtist, const wchar_t* pTitle)
+{
+	DWORD dwMaxCount = dwBufferSize - 1U;
+
+	if (wcslen(pTitle) != 0U)
+		if (wcslen(pArtist) != 0U)
+			_snwprintf_s(pBuffer, dwBufferSize, dwMaxCount, L"%s - %s\0", pArtist, pTitle);
+
+		else
+			_snwprintf_s(pBuffer, dwBufferSize, dwMaxCount, L"%s\0", pTitle);
+	else
+		_snwprintf_s(pBuffer, dwBufferSize, dwMaxCount, L"%s\0", pArtist);
+
+}
 
 #endif

--- a/WinAudio/WA_UI_ListView.h
+++ b/WinAudio/WA_UI_ListView.h
@@ -14,8 +14,7 @@
 #define WA_LISTVIEW_COLUMNS_COUNT           8
 #define WA_LISTVIEW_PRINTF_MAX              100
 
-#define WA_LISTVIEW_CACHING_TIMEOUT         50 // In Ms
-
+#define WA_LISTVIEW_CACHING_TIMEOUT         200 // In Ms
 
 // Store Columns Order and Visibility
 typedef struct TagWA_Listview_Column


### PR DESCRIPTION
Implemented sorting in playlist: now when the user click on the listview header, a qsort is performed. "Status" and "Index" are skipped from ordering. Fix a bug in WA_Playlist_LoadM3U: a null teminating char is inserted at the end of the buffer that contains file paths. In this way,  no invalid charachters are added into the UFT_16 converted buffer. Removed PathFileExist because it slow loading of files that are on SMB share. A PathFileExist is perfomed during file opening..