### PR TITLE
Fix some bugs on ordering functions and some other fixes

### DIFF
--- a/WinAudio/SearchDlg.c
+++ b/WinAudio/SearchDlg.c
@@ -128,7 +128,7 @@ INT_PTR CALLBACK SearchDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lP
 
                 if (nSelectedItem != LB_ERR)
                 {
-                    nItemIndex = ListBox_GetItemData(GetDlgItem(hDlg, IDC_SEARCH_DLG_LIST), nSelectedItem);
+                    nItemIndex = (int32_t) ListBox_GetItemData(GetDlgItem(hDlg, IDC_SEARCH_DLG_LIST), nSelectedItem);
 
                     if (nItemIndex != LB_ERR)
                     {                      

--- a/WinAudio/WA_GEN_Playlist.c
+++ b/WinAudio/WA_GEN_Playlist.c
@@ -775,13 +775,14 @@ static int WA_Playlist_Cmp_Duration(void* order, const void* obj1, const void* o
 		else
 			nResult = -1;
 
+		break;
 	case WA_PLAYLIST_SORT_DOWN:
 		if (p1->uFileDurationMs == p2->uFileDurationMs)
 			nResult = 0;
-		else if (p1->uFileDurationMs > p2->uFileDurationMs)
-			nResult = -1;
-		else
+		else if (p2->uFileDurationMs > p1->uFileDurationMs)
 			nResult = 1;
+		else
+			nResult = -1;
 
 	}
 

--- a/WinAudio/main.c
+++ b/WinAudio/main.c
@@ -196,8 +196,9 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
         MainWindow_CopyData(hExistingWindow, __argc, __wargv);
 
         // Show Existing Window
-        SetForegroundWindow(hExistingWindow);
-        ShowWindow(hExistingWindow, SW_RESTORE);
+        // // TODO: Check if it is userful to add this option on settings page
+        //SetForegroundWindow(hExistingWindow);
+        //ShowWindow(hExistingWindow, SW_RESTORE);
 
         _RPTFW0(_CRT_WARN, L"Found an already opened instance\n");
 


### PR DESCRIPTION
1. Fix bug on header ordering. Now, before request a header item, the mask field of HDITEM is filled with proper flags and text of the header index is filled again before update the header item (according to microsoft docs).  
2. Duration compare function now order items in correct order. 
3. Add a missing break on  WA_UI_Listview_ShowItemContextMenu 
4. Now main window don't show the existing window of an existing instance when a file is opened from the windows explorer